### PR TITLE
Fix: PlotlyFigure layout and sizing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Embed interactive Plotly figures in your slides.
 - `src`: Path to the Plotly figure JSON file (required)
 - `caption`: Figure caption text (required)
 - `width`: Figure width (optional, default: "100%")
-- `height`: Figure height (optional, default: "100%")
+- `height`: Figure height (optional, default: "360px")
 - `fontSize`: Font size for the figure (optional, number)
 
 ### ImageFigure Component

--- a/components/PlotlyFigure.vue
+++ b/components/PlotlyFigure.vue
@@ -17,7 +17,7 @@ const resizeObserver = ref<ResizeObserver | null>(null);
 // set container style
 const containerStyle = computed(() => ({
   width: props.width || "100%",
-  height: props.height || "100%",
+  height: props.height || "360px",
 }));
 
 // get current font family
@@ -126,11 +126,13 @@ onMounted(initPlot);
 </script>
 
 <template>
-  <div
-    class="grid grid-rows-[auto_40px] justify-content-center justify-items-center overflow-hidden"
-  >
-    <div ref="plotDiv" :style="containerStyle"></div>
-    <div v-if="caption" class="text-xs">
+  <div class="w-full">
+    <div
+      class="mx-auto"
+      :style="[containerStyle, { margin: '0 auto' }]"
+      ref="plotDiv"
+    ></div>
+    <div v-if="caption" class="text-xs text-center mt-2">
       {{ caption }}
     </div>
   </div>

--- a/example.md
+++ b/example.md
@@ -19,8 +19,35 @@ You can embed interactive Plotly figures in your slides!
 <PlotlyFigure
   src="figure.json"
   caption="Figure N: Figure Caption."
-  width="100%"
-  height="320px"
+/>
+```
+
+</div>
+<div>
+
+<PlotlyFigure
+  src="figure.json"
+  caption="Figure N: Figure Caption."
+/>
+
+</div>
+</div>
+
+---
+
+# Component: `PlotlyFigure`
+
+You can specify the width, height, and font size of the figure.
+
+<div grid="~ cols-2 gap-4">
+<div>
+
+```markdown
+<PlotlyFigure
+  src="figure.json"
+  caption="Figure N: Figure Caption."
+  width="300px"
+  height="200px"
   :fontSize="10"
 />
 ```
@@ -31,8 +58,8 @@ You can embed interactive Plotly figures in your slides!
 <PlotlyFigure
   src="figure.json"
   caption="Figure N: Figure Caption."
-  width="100%"
-  height="320px"
+  width="300px"
+  height="200px"
   :fontSize="10"
 />
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slidev-addon-stem",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Slidev addon for plotly figure rendering and etc.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
This PR addresses the initial width rendering issues with PlotlyFigure component.

## Changes
- Fixed initial width rendering issue
- Implemented center alignment for fixed-width figures
- Resolved overflow issues for full-width figures
- Simplified layout structure
- Improved documentation and demo examples
- Bumped version to 0.1.0

## Testing
- Tested with both fixed width (100px × 100px) and full width (100% × 320px) figures
- Verified proper centering and overflow handling
- Confirmed documentation accuracy

Fixes #1